### PR TITLE
Make compatible with recent Enhydris changes (fixes #22)

### DIFF
--- a/enhydris_synoptic/tests/data.py
+++ b/enhydris_synoptic/tests/data.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 from django.contrib.gis.geos import Point
 
-from enhydris.models import Station, Timeseries
+from enhydris.models import Station, Timeseries, Variable
 from model_mommy import mommy
 
 from enhydris_synoptic.models import (
@@ -19,6 +19,7 @@ class TestData:
         self._create_stations()
         self._create_synoptic_group()
         self._create_synoptic_group_stations()
+        self._create_variables()
         self._create_timeseries()
         self._create_synoptic_timeseries()
         self._create_timeseries_data()
@@ -52,6 +53,12 @@ class TestData:
             order=2,
         )
 
+    def _create_variables(self):
+        self.var_rain = mommy.make(Variable, descr="Rain")
+        self.var_temperature = mommy.make(Variable, descr="Temperature")
+        self.var_wind_speed = mommy.make(Variable, descr="Wind speed")
+        self.var_wind_gust = mommy.make(Variable, descr="Wind gust")
+
     def _create_timeseries(self):
         self._create_timeseries_for_komboti()
         self._create_timeseries_for_agios()
@@ -60,7 +67,9 @@ class TestData:
         self.ts_komboti_rain = mommy.make(
             Timeseries,
             gentity=self.station_komboti,
+            variable=self.var_rain,
             name="Rain",
+            precision=0,
             unit_of_measurement__symbol="mm",
             time_zone__code="EET",
             time_zone__utc_offset=120,
@@ -68,7 +77,9 @@ class TestData:
         self.ts_komboti_temperature = mommy.make(
             Timeseries,
             gentity=self.station_komboti,
+            variable=self.var_temperature,
             name="Air temperature",
+            precision=0,
             unit_of_measurement__symbol="°C",
             time_zone__code="EET",
             time_zone__utc_offset=120,
@@ -76,6 +87,7 @@ class TestData:
         self.ts_komboti_wind_speed = mommy.make(
             Timeseries,
             gentity=self.station_komboti,
+            variable=self.var_wind_speed,
             name="Wind speed",
             precision=1,
             unit_of_measurement__symbol="m/s",
@@ -85,6 +97,7 @@ class TestData:
         self.ts_komboti_wind_gust = mommy.make(
             Timeseries,
             gentity=self.station_komboti,
+            variable=self.var_wind_gust,
             name="Wind gust",
             precision=1,
             unit_of_measurement__symbol="m/s",
@@ -96,6 +109,7 @@ class TestData:
         self.ts_agios_rain = mommy.make(
             Timeseries,
             gentity=self.station_agios,
+            variable=self.var_rain,
             name="Rain",
             precision=1,
             unit_of_measurement__symbol="mm",
@@ -105,6 +119,7 @@ class TestData:
         self.ts_agios_temperature = mommy.make(
             Timeseries,
             gentity=self.station_agios,
+            variable=self.var_temperature,
             name="Air temperature",
             precision=1,
             unit_of_measurement__symbol="°C",

--- a/enhydris_synoptic/views.py
+++ b/enhydris_synoptic/views.py
@@ -6,11 +6,11 @@ to do such offline rendering. It doesn't know about requests and responses, and 
 doesn't know about HTTP. But logically it's the "views" part of a Django app.
 """
 import os
-from collections import namedtuple
 from io import BytesIO
 
 from django.conf import settings
 from django.contrib.gis.db.models import Extent
+from django.http import HttpRequest
 from django.template.loader import render_to_string
 
 import matplotlib
@@ -102,7 +102,7 @@ def _render_only_group(synoptic_group):
 
 
 def _get_map_js(sgroup):
-    dummy_request = namedtuple("dummy_request", ["map_viewport"])
+    dummy_request = HttpRequest()
     dummy_request.map_viewport = _get_bounding_box(sgroup)
     return enhydris.context_processors.map(dummy_request)["map_js"]
 


### PR DESCRIPTION
These changes are because of these Enhydris changes:
1) Enhydris now handles Timeseries.precision better;
2) Enhydris now has Variable as a translatable model;
3) Enhydris now does more in the map() context processor.