### PR TITLE
Make map js compatible with recent Enhydris changes

### DIFF
--- a/enhydris_synoptic/templates/enhydris-synoptic/group-default.html
+++ b/enhydris_synoptic/templates/enhydris-synoptic/group-default.html
@@ -40,7 +40,11 @@
   <script type="text/javascript" src="{% static "js/L.Control.MousePosition.js" %}"></script>
   <script type="text/javascript" src="{% static "js/leaflet.groupedlayercontrol.min.js" %}"></script>
   <script type="text/javascript">
-    {{ map_js | safe }}
+    enhydris.mapBaseLayers = {{ map_base_layers|safe }};
+    enhydris.mapDefaultBaseLayer = "{{ map_default_base_layer|safe }}";
+    enhydris.mapViewport = {{ map_viewport|safe }};
+    enhydris.mapMarkers = {{ map_markers|safe }};
+    enhydris.searchString = {{ searchString|safe }};
     enhydris.mapStations = [];
     {% for object in object.synopticgroupstation_set.all %}
       enhydris.mapStations.push({

--- a/enhydris_synoptic/views.py
+++ b/enhydris_synoptic/views.py
@@ -93,18 +93,16 @@ def render_synoptic_group(synoptic_group):
 
 
 def _render_only_group(synoptic_group):
-    output = render_to_string(
-        "enhydris-synoptic/group.html",
-        context={"object": synoptic_group, "map_js": _get_map_js(synoptic_group)},
-    )
+    context = {"object": synoptic_group, **_get_map_context(synoptic_group)}
+    output = render_to_string("enhydris-synoptic/group.html", context=context)
     filename = os.path.join(synoptic_group.slug, "index.html")
     File(filename).write(output)
 
 
-def _get_map_js(sgroup):
+def _get_map_context(sgroup):
     dummy_request = HttpRequest()
     dummy_request.map_viewport = _get_bounding_box(sgroup)
-    return enhydris.context_processors.map(dummy_request)["map_js"]
+    return enhydris.context_processors.map(dummy_request)
 
 
 def _get_bounding_box(sgroup):


### PR DESCRIPTION
Enhydris commit e26d23c changed the way the map javascript works; this
makes synoptic compatible with these changes.