### PR TITLE
Fix page header in station page (fixes #74)

### DIFF
--- a/enhydris_synoptic/templates/enhydris-synoptic/groupstation-default.html
+++ b/enhydris_synoptic/templates/enhydris-synoptic/groupstation-default.html
@@ -1,6 +1,12 @@
 {% extends "enhydris-synoptic/base.html" %}
 {% load i18n %}
 
+{% block extracss %}
+  <style>
+    header.page-header { position: relative; };
+  </style>
+{% endblock %}
+
 {% block title %}
   {% blocktrans with name=object.station.name %}
     Conditions at {{ name }}


### PR DESCRIPTION
In practically all enhydris pages, the page header (i.e. the navbar) has
"position: absolute" and partially covers the map. However, in the
synoptic station view there's no map, so we change this to "position:
relative" so that the contents of the page aren't covered by the navbar.