### PR TITLE
Revert "Fix page header in station page (fixes #74)"

### DIFF
--- a/enhydris_synoptic/templates/enhydris-synoptic/groupstation-default.html
+++ b/enhydris_synoptic/templates/enhydris-synoptic/groupstation-default.html
@@ -1,12 +1,6 @@
 {% extends "enhydris-synoptic/base.html" %}
 {% load i18n %}
 
-{% block extracss %}
-  <style>
-    header.page-header { position: relative; };
-  </style>
-{% endblock %}
-
 {% block title %}
   {% blocktrans with name=object.station.name %}
     Conditions at {{ name }}


### PR DESCRIPTION
This has been fixed in Enhydris, so it's no longer needed here.